### PR TITLE
Disabling APC default caching.

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,7 @@
+; This is a simple php.ini file on App Engine
+; It enables output buffering for all requests by overriding the
+; default setting of the PHP interpreter.
+
+; Disable default APC cache as does not play nicely with Appengine at the moment.
+; See: https://groups.google.com/forum/#!topic/google-appengine/ju6jkCLAvyE
+apc.cache_by_default = 0


### PR DESCRIPTION
Disabling default APC caching as it does not play nicely with Appengine at the moment, see: https://groups.google.com/forum/#!topic/google-appengine/ju6jkCLAvyE

Essentially every other load of the application will 500 because of an APC bug unless this ini setting is overridden, tested on several installs.

This setting can be removed once fixed by the Appengine team but in the meantime it will save developers using this repository unnecessary pain.
